### PR TITLE
Add cache freshness option to the S3 cache plugin

### DIFF
--- a/lib/plugins/s3HtmlCache.js
+++ b/lib/plugins/s3HtmlCache.js
@@ -40,9 +40,15 @@ var s3_cache = {
             key = process.env.S3_PREFIX_KEY + '/' + key;
         }
 
-        s3.getObject({
+        var options = {
             Key: key
-        }, callback);
+        };
+        
+        if (process.env.S3_CACHE_TTL) {
+            options.IfModifiedSince = (Date.now() / 1000) - (process.env.S3_CACHE_TTL * 60 * 60);
+        }
+
+        s3.getObject(options, callback);
     },
     set: function(key, value, callback) {
         if (process.env.S3_PREFIX_KEY) {


### PR DESCRIPTION
Optionally use an S3_CACHE_TTL environment variable to only fetch objects modified in
the last x hours. For example, setting the variable to 24 will force the cache to bypass
and recache files more than a day old.

Makes use of the IfModifiedSince parameter available in aws-sdk.S3#getObject.
http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getObject-property
